### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/instantOS/instantCLI/compare/v0.1.5...v0.1.6) - 2025-09-27
+
+### Fixed
+
+- fix missing
+
 ## [0.1.5](https://github.com/instantOS/instantCLI/compare/v0.1.4...v0.1.5) - 2025-09-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.1.5
+pkgver=0.1.6
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION



## 🤖 New release

* `ins`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/instantOS/instantCLI/compare/v0.1.5...v0.1.6) - 2025-09-27

### Fixed

- fix missing
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).