### PR TITLE
chore: release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/instantOS/instantCLI/compare/v0.1.7...v0.1.8) - 2025-09-27
+
+### Fixed
+
+- fix permission error
+
 ## [0.1.7](https://github.com/instantOS/instantCLI/compare/v0.1.6...v0.1.7) - 2025-09-27
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"


### PR DESCRIPTION



## 🤖 New release

* `ins`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.8](https://github.com/instantOS/instantCLI/compare/v0.1.7...v0.1.8) - 2025-09-27

### Fixed

- fix permission error
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).