### PR TITLE
Configure release-plz to include changelog in GitHub releases

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,3 @@
+[workspace]
+git_release_enable = true
+git_release_body = "{{ changelog }}"


### PR DESCRIPTION
This PR configures release-plz to automatically include the changelog content in GitHub release notes.

Currently, GitHub releases are created with empty bodies. This configuration change will ensure that future releases automatically include the relevant changelog content, making it easier for users to understand what's changed in each release.

The configuration uses the  setting which tells release-plz to embed the generated changelog directly in the GitHub release body.