### PR TITLE
chore: release v0.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.11](https://github.com/instantOS/instantCLI/compare/v0.6.10...v0.6.11) - 2025-11-19
+
+### Fixed
+
+- *(ci)* use cargo-ndk for android termux builds to resolve linking issues
+
+### Other
+
+- make self hosted
+- refactor launch handle function
+
 ## [0.6.10](https://github.com/instantOS/instantCLI/compare/v0.6.9...v0.6.10) - 2025-11-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"


### PR DESCRIPTION



## 🤖 New release

* `ins`: 0.6.10 -> 0.6.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.6.11](https://github.com/instantOS/instantCLI/compare/v0.6.10...v0.6.11) - 2025-11-19

### Fixed

- *(ci)* use cargo-ndk for android termux builds to resolve linking issues

### Other

- make self hosted
- refactor launch handle function
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved linking issues affecting Android Termux builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->