### PR TITLE
chore: release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/instantOS/instantCLI/compare/v0.8.1...v0.8.2) - 2025-12-03
+
+### Fixed
+
+- fix ins binary conflict
+- fix plymouth
+- fix cfdisk sigint handling
+- fix cfdisk again
+- fix cfdisk
+
+### Other
+
+- make ins arch setup better
+- ilovecandy
+- add clipmenud dep
+- fmt
+- fmt
+- tty is finicky
+- better get_default
+- add mirror shuffling
+
 ## [0.8.1](https://github.com/instantOS/instantCLI/compare/v0.8.0...v0.8.1) - 2025-12-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"

--- a/pkgbuild/ins/.SRCINFO
+++ b/pkgbuild/ins/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ins
 	pkgdesc = A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations
-	pkgver = 0.8.1
+	pkgver = 0.8.2
 	pkgrel = 1
 	url = https://github.com/instantOS/instantCLI
 	arch = x86_64
@@ -14,7 +14,7 @@ pkgbase = ins
 	optdepends = restic: for backup functionality
 	optdepends = kitty: default terminal for scratchpad
 	options = !lto
-	source = ins-0.8.1.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.8.1.tar.gz
+	source = ins-0.8.2.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.8.2.tar.gz
 	sha256sums = SKIP
 
 pkgname = ins

--- a/pkgbuild/ins/PKGBUILD
+++ b/pkgbuild/ins/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.8.1
+pkgver=0.8.2
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION



## 🤖 New release

* `ins`: 0.8.1 -> 0.8.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.8.2](https://github.com/instantOS/instantCLI/compare/v0.8.1...v0.8.2) - 2025-12-03

### Fixed

- fix ins binary conflict
- fix plymouth
- fix cfdisk sigint handling
- fix cfdisk again
- fix cfdisk

### Other

- make ins arch setup better
- ilovecandy
- add clipmenud dep
- fmt
- fmt
- tty is finicky
- better get_default
- add mirror shuffling
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 0.8.2

* **Bug Fixes**
  * Fixed ins binary conflict
  * Fixed plymouth support
  * Fixed cfdisk signal interrupt handling
  * Fixed additional cfdisk issues
  * Various behavioral and auxiliary improvements

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->