### PR TITLE
chore: release v0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4](https://github.com/instantOS/instantCLI/compare/v0.8.3...v0.8.4) - 2025-12-03
+
+### Fixed
+
+- fix CI, make default dotfile repo read-only
+
 ## [0.8.3](https://github.com/instantOS/instantCLI/compare/v0.8.2...v0.8.3) - 2025-12-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"


### PR DESCRIPTION



## 🤖 New release

* `ins`: 0.8.3 -> 0.8.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.8.4](https://github.com/instantOS/instantCLI/compare/v0.8.3...v0.8.4) - 2025-12-03

### Fixed

- fix CI, make default dotfile repo read-only
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CI-related issues
  * Default dotfile repository is now read-only

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->