### PR TITLE
chore: release v0.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.6](https://github.com/instantOS/instantCLI/compare/v0.10.5...v0.10.6) - 2025-12-10
+
+### Fixed
+
+- fix pacman-contrib missing
+- fix instant repo order
+- fix iso pacman
+- fix package installation order
+- fix dual boot efi dir
+- fix ESP detection
+- fix disk cache
+- fix wrong partition being used?
+- fix dual boot handling
+- fix dual boot partition creation
+
+### Other
+
+- plans
+- installmore idea
+- add jank plans
+- better checks
+- set up default user with wallpaper
+- better error management
+- better error handling
+- install packages earlier
+- partition deletion detection
+- cap swap so it's not absurd
+- fmt
+- use largest free region instead of total space
+- I hate disk stuff
+- another fix?
+- better json
+- reduce amount of needed cowspace
+- more sfdisk fixes
+- switch to json
+- create dualboot root in appropriate space
+- account for fragmented storage
+- deduplicate some stuff
+- check sizes after creating partitions
+- proper types for partitions
+- dynamically update shrinking message
+- refactor disk preparation
+
 ## [0.10.5](https://github.com/instantOS/instantCLI/compare/v0.10.4...v0.10.5) - 2025-12-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.10.5"
+version = "0.10.6"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"

--- a/pkgbuild/ins/.SRCINFO
+++ b/pkgbuild/ins/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ins
 	pkgdesc = A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations
-	pkgver = 0.10.5
+	pkgver = 0.10.6
 	pkgrel = 1
 	url = https://instantos.io
 	arch = x86_64
@@ -14,7 +14,7 @@ pkgbase = ins
 	optdepends = restic: for backup functionality
 	optdepends = kitty: default terminal for scratchpad
 	options = !lto
-	source = ins-0.10.5.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.10.5.tar.gz
+	source = ins-0.10.6.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.10.6.tar.gz
 	sha256sums = SKIP
 
 pkgname = ins

--- a/pkgbuild/ins/PKGBUILD
+++ b/pkgbuild/ins/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.10.5
+pkgver=0.10.6
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION



## 🤖 New release

* `ins`: 0.10.5 -> 0.10.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.10.6](https://github.com/instantOS/instantCLI/compare/v0.10.5...v0.10.6) - 2025-12-10

### Fixed

- fix pacman-contrib missing
- fix instant repo order
- fix iso pacman
- fix package installation order
- fix dual boot efi dir
- fix ESP detection
- fix disk cache
- fix wrong partition being used?
- fix dual boot handling
- fix dual boot partition creation

### Other

- plans
- installmore idea
- add jank plans
- better checks
- set up default user with wallpaper
- better error management
- better error handling
- install packages earlier
- partition deletion detection
- cap swap so it's not absurd
- fmt
- use largest free region instead of total space
- I hate disk stuff
- another fix?
- better json
- reduce amount of needed cowspace
- more sfdisk fixes
- switch to json
- create dualboot root in appropriate space
- account for fragmented storage
- deduplicate some stuff
- check sizes after creating partitions
- proper types for partitions
- dynamically update shrinking message
- refactor disk preparation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.10.6

* **Chores**
  * Released version 0.10.6 with multiple bug fixes and improvements. Updated package configuration files and version metadata across all build systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->