### PR TITLE
chore: release v0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.3](https://github.com/instantOS/instantCLI/compare/v0.12.2...v0.12.3) - 2026-01-19
+
+### Fixed
+
+- fix game sync bug (file time was lost)
+- fix docs and behavior being different
+- fix docs macro
+- fix bad category architecture
+- fix memory leak
+
+### Other
+
+- better preview builder
+- better default video player setting
+- better add_repo prompt
+- better default image viewer preview
+- better default app settings
+- more cursor tracking
+- more cursor tracking
+- refactor alternative mod.rs
+- track cursor position for `ins game menu`
+- more cursor tracking
+- migrate edit menu
+- migrate settings menu to new cursor system
+- init better menu cursors
+- init better non-interactive alternative
+- cleaner docs macro
+- more documented toml
+- less default shite being added
+- serde stuff
+- better updates for local repos
+- init shell menu entry
+- init lg and shell command
+- open in lazygit option
+- add is_external check for repos
+- type alais
+- add `unit` dot subcommand
+- set new dotfile picker as hidden
+- add default_subdirs
+- remove default dotfile dir thingy
+- refactor apply_all
+- integrate units into apply
+- init dotfile units
+- init plan
+
 ## [0.12.2](https://github.com/instantOS/instantCLI/compare/v0.12.1...v0.12.2) - 2026-01-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"

--- a/pkgbuild/ins/.SRCINFO
+++ b/pkgbuild/ins/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ins
 	pkgdesc = A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations
-	pkgver = 0.12.2
+	pkgver = 0.12.3
 	pkgrel = 1
 	url = https://instantos.io
 	arch = x86_64
@@ -14,7 +14,7 @@ pkgbase = ins
 	optdepends = restic: for backup functionality
 	optdepends = kitty: default terminal for scratchpad
 	options = !lto
-	source = ins-0.12.2.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.12.2.tar.gz
+	source = ins-0.12.3.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.12.3.tar.gz
 	sha256sums = SKIP
 
 pkgname = ins

--- a/pkgbuild/ins/PKGBUILD
+++ b/pkgbuild/ins/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.12.2
+pkgver=0.12.3
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION



## 🤖 New release

* `ins`: 0.12.2 -> 0.12.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.12.3](https://github.com/instantOS/instantCLI/compare/v0.12.2...v0.12.3) - 2026-01-19

### Fixed

- fix game sync bug (file time was lost)
- fix docs and behavior being different
- fix docs macro
- fix bad category architecture
- fix memory leak

### Other

- better preview builder
- better default video player setting
- better add_repo prompt
- better default image viewer preview
- better default app settings
- more cursor tracking
- more cursor tracking
- refactor alternative mod.rs
- track cursor position for `ins game menu`
- more cursor tracking
- migrate edit menu
- migrate settings menu to new cursor system
- init better menu cursors
- init better non-interactive alternative
- cleaner docs macro
- more documented toml
- less default shite being added
- serde stuff
- better updates for local repos
- init shell menu entry
- init lg and shell command
- open in lazygit option
- add is_external check for repos
- type alais
- add `unit` dot subcommand
- set new dotfile picker as hidden
- add default_subdirs
- remove default dotfile dir thingy
- refactor apply_all
- integrate units into apply
- init dotfile units
- init plan
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).