### PR TITLE
chore: release v0.13.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fix release thingy
 
+### Other
+
+- release v0.13.14
+
+## [0.13.15](https://github.com/instantOS/instantCLI/compare/v0.13.14...v0.13.15) - 2026-02-23
+
+### Fixed
+
+- fix release thingy
+
 ## [0.13.14](https://github.com/instantOS/instantCLI/compare/v0.13.13...v0.13.14) - 2026-02-23
 
 ### Fixed

--- a/pkgbuild/ins/.SRCINFO
+++ b/pkgbuild/ins/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ins
 	pkgdesc = A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations
-	pkgver = 0.13.10
+	pkgver = 0.13.15
 	pkgrel = 1
 	url = https://instantos.io
 	arch = x86_64
@@ -14,7 +14,7 @@ pkgbase = ins
 	optdepends = restic: for backup functionality
 	optdepends = kitty: default terminal for scratchpad
 	options = !lto
-	source = ins-0.13.10.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.10.tar.gz
+	source = ins-0.13.15.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.15.tar.gz
 	sha256sums = SKIP
 
 pkgname = ins

--- a/pkgbuild/ins/PKGBUILD
+++ b/pkgbuild/ins/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.13.10
+pkgver=0.13.15
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION
## 🤖 New release

* `ins`: 0.13.14 -> 0.13.15

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.13.15](https://github.com/instantOS/instantCLI/compare/v0.13.14...v0.13.15) - 2026-02-23

### Fixed

- fix release thingy

### Other

- release v0.13.14
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

## Summary by Sourcery

Documentation:
- Document the 0.13.15 release details and prior 0.13.14 release in CHANGELOG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated changelog with a new "Other" subsection and prepared a placeholder entry for release v0.13.14 plus an upcoming v0.13.15.
  * Bumped package version to v0.13.15 and updated packaging references to point to the new release artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->