### PR TITLE
chore: release v0.13.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.16](https://github.com/instantOS/instantCLI/compare/v0.13.15...v0.13.16) - 2026-02-24
+
+### Other
+
+- sync PKGBUILD version
+- release v0.13.15
+
 ## [0.13.15](https://github.com/instantOS/instantCLI/compare/v0.13.14...v0.13.15) - 2026-02-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.13.15"
+version = "0.13.16"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.13.15"
+version = "0.13.16"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"

--- a/pkgbuild/ins/.SRCINFO
+++ b/pkgbuild/ins/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ins
 	pkgdesc = A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations
-	pkgver = 0.13.15
+	pkgver = 0.13.16
 	pkgrel = 1
 	url = https://instantos.io
 	arch = x86_64
@@ -14,7 +14,7 @@ pkgbase = ins
 	optdepends = restic: for backup functionality
 	optdepends = kitty: default terminal for scratchpad
 	options = !lto
-	source = ins-0.13.15.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.15.tar.gz
+	source = ins-0.13.16.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.16.tar.gz
 	sha256sums = SKIP
 
 pkgname = ins

--- a/pkgbuild/ins/PKGBUILD
+++ b/pkgbuild/ins/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.13.15
+pkgver=0.13.16
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION
## 🤖 New release

* `ins`: 0.13.15 -> 0.13.16

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.13.16](https://github.com/instantOS/instantCLI/compare/v0.13.15...v0.13.16) - 2026-02-24

### Other

- sync PKGBUILD version
- release v0.13.15
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

## Summary by Sourcery

Release version 0.13.16 of the `ins` crate and update related metadata.

Build:
- Bump crate version from 0.13.15 to 0.13.16 in Cargo metadata.

Documentation:
- Add 0.13.16 entry to the changelog documenting the release and PKGBUILD sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.13.16
  * Updated release documentation with version information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->