### PR TITLE
chore: release v0.13.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.21](https://github.com/instantOS/instantCLI/compare/v0.13.20...v0.13.21) - 2026-04-09
+
+### Fixed
+
+- fix test
+- fix sudo settings on non-wheel systems
+
+### Other
+
+- add swap escape setting for instantwm
+- init german support for `ins video`
+- create instantwm config if not present
+- init instantwm setup support
+
 ## [0.13.20](https://github.com/instantOS/instantCLI/compare/v0.13.19...v0.13.20) - 2026-04-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.13.20"
+version = "0.13.21"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"

--- a/pkgbuild/ins/.SRCINFO
+++ b/pkgbuild/ins/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ins
 	pkgdesc = A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations
-	pkgver = 0.13.20
+	pkgver = 0.13.21
 	pkgrel = 1
 	url = https://instantos.io
 	arch = x86_64
@@ -14,7 +14,7 @@ pkgbase = ins
 	optdepends = restic: for backup functionality
 	optdepends = kitty: default terminal for scratchpad
 	options = !lto
-	source = ins-0.13.20.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.20.tar.gz
+	source = ins-0.13.21.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.21.tar.gz
 	sha256sums = SKIP
 
 pkgname = ins

--- a/pkgbuild/ins/PKGBUILD
+++ b/pkgbuild/ins/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.13.20
+pkgver=0.13.21
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION



## 🤖 New release

* `ins`: 0.13.20 -> 0.13.21

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.13.21](https://github.com/instantOS/instantCLI/compare/v0.13.20...v0.13.21) - 2026-04-09

### Fixed

- fix test
- fix sudo settings on non-wheel systems

### Other

- add swap escape setting for instantwm
- init german support for `ins video`
- create instantwm config if not present
- init instantwm setup support
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Added release notes for v0.13.21 (2026-04-09).

* **New Features**
  * German language support for video functionality.
  * Improved instantwm integration with automatic setup, safer config creation, and configurable escape-key behavior.

* **Bug Fixes**
  * Fixed sudo permission handling on systems without wheel users.

* **Chores**
  * Package/version updated to v0.13.21.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->