### PR TITLE
chore: release v0.13.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.24](https://github.com/instantOS/instantCLI/compare/v0.13.23...v0.13.24) - 2026-04-20
+
+### Fixed
+
+- fix wheel permission error
+- fix swapescape for instantwm
+
+### Other
+
+- make ins arch more testable
+- more tests
+
 ## [0.13.23](https://github.com/instantOS/instantCLI/compare/v0.13.22...v0.13.23) - 2026-04-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.13.23"
+version = "0.13.24"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.13.23"
+version = "0.13.24"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"

--- a/pkgbuild/ins/.SRCINFO
+++ b/pkgbuild/ins/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ins
 	pkgdesc = A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations
-	pkgver = 0.13.23
+	pkgver = 0.13.24
 	pkgrel = 1
 	url = https://instantos.io
 	arch = x86_64
@@ -14,7 +14,7 @@ pkgbase = ins
 	optdepends = restic: for backup functionality
 	optdepends = kitty: default terminal for scratchpad
 	options = !lto
-	source = ins-0.13.23.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.23.tar.gz
+	source = ins-0.13.24.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.24.tar.gz
 	sha256sums = SKIP
 
 pkgname = ins

--- a/pkgbuild/ins/PKGBUILD
+++ b/pkgbuild/ins/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.13.23
+pkgver=0.13.24
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION



## 🤖 New release

* `ins`: 0.13.23 -> 0.13.24

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.13.24](https://github.com/instantOS/instantCLI/compare/v0.13.23...v0.13.24) - 2026-04-20

### Fixed

- fix wheel permission error
- fix swapescape for instantwm

### Other

- make ins arch more testable
- more tests
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wheel permission error, preventing permission failures during device access.
  * Fixed swapescape for instantwm, restoring expected window-switching behavior.

* **Tests**
  * Added more tests to improve overall reliability.
  * Improved architecture testability to make core components easier to validate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->