### PR TITLE
chore: release v0.13.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.26](https://github.com/instantOS/instantCLI/compare/v0.13.25...v0.13.26) - 2026-04-24
+
+### Fixed
+
+- fix pass gui handling
+- fix extra otp noise
+- fix OTP behavior
+- fix key issues with ins pass
+
+### Other
+
+- Merge pull request #134 from instantOS/release-plz-2026-04-21T17-40-57Z
+- Merge branch 'dev'
+- add better ins pass file filtering
+- better edit thingy
+- separate pass and pass menu
+- better default fzf key implementation
+- clean up pass
+- make wine discovery more readable
+- Merge branch 'dev' of github.com:instantOS/instantCLI into dev
+- desloppify pass menu
+- better pass CLI
+- add ignore dep
+- init ins dot insignore feature
+- password edit menu
+- prettier pass preview
+- init `ins pass`
+- speed up `ins launch`
+- add more niri support
+
 ## [0.13.25](https://github.com/instantOS/instantCLI/compare/v0.13.24...v0.13.25) - 2026-04-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.13.25"
+version = "0.13.26"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.13.25"
+version = "0.13.26"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"

--- a/pkgbuild/ins/.SRCINFO
+++ b/pkgbuild/ins/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ins
 	pkgdesc = A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations
-	pkgver = 0.13.25
+	pkgver = 0.13.26
 	pkgrel = 1
 	url = https://instantos.io
 	arch = x86_64
@@ -14,7 +14,7 @@ pkgbase = ins
 	optdepends = restic: for backup functionality
 	optdepends = kitty: default terminal for scratchpad
 	options = !lto
-	source = ins-0.13.25.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.25.tar.gz
+	source = ins-0.13.26.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.26.tar.gz
 	sha256sums = SKIP
 
 pkgname = ins

--- a/pkgbuild/ins/PKGBUILD
+++ b/pkgbuild/ins/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.13.25
+pkgver=0.13.26
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION



## 🤖 New release

* `ins`: 0.13.25 -> 0.13.26

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.13.26](https://github.com/instantOS/instantCLI/compare/v0.13.25...v0.13.26) - 2026-04-24

### Fixed

- fix pass gui handling
- fix extra otp noise
- fix OTP behavior
- fix key issues with ins pass

### Other

- Merge pull request #134 from instantOS/release-plz-2026-04-21T17-40-57Z
- Merge branch 'dev'
- add better ins pass file filtering
- better edit thingy
- separate pass and pass menu
- better default fzf key implementation
- clean up pass
- make wine discovery more readable
- Merge branch 'dev' of github.com:instantOS/instantCLI into dev
- desloppify pass menu
- better pass CLI
- add ignore dep
- init ins dot insignore feature
- password edit menu
- prettier pass preview
- init `ins pass`
- speed up `ins launch`
- add more niri support
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GUI handling for pass, OTP behavior and noise issues, and key problems

* **Improvements**
  * Menu restructuring, fzf key behavior enhancements, pass cleanup and preview formatting, password edit menu updates, initialization improvements, launch speed optimizations, wine discovery readability, and added niri support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->