### PR TITLE
chore: release v0.13.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.27](https://github.com/instantOS/instantCLI/compare/v0.13.26...v0.13.27) - 2026-04-27
+
+### Other
+
+- update readme
+- better `ins arch` error handling
+- add desktop environment question to `ins arch`
+- more encapsulation
+- better push handling of local only repos
+- cleaner preview method
+- cleaner exit
+- skip repos which ignore file in menu
+- earlier ignore checks
+- home dir support for ins ignore
+
 ## [0.13.26](https://github.com/instantOS/instantCLI/compare/v0.13.25...v0.13.26) - 2026-04-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.13.26"
+version = "0.13.27"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.13.26"
+version = "0.13.27"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"

--- a/pkgbuild/ins/.SRCINFO
+++ b/pkgbuild/ins/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ins
 	pkgdesc = A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations
-	pkgver = 0.13.26
+	pkgver = 0.13.27
 	pkgrel = 1
 	url = https://instantos.io
 	arch = x86_64
@@ -14,7 +14,7 @@ pkgbase = ins
 	optdepends = restic: for backup functionality
 	optdepends = kitty: default terminal for scratchpad
 	options = !lto
-	source = ins-0.13.26.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.26.tar.gz
+	source = ins-0.13.27.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.27.tar.gz
 	sha256sums = SKIP
 
 pkgname = ins

--- a/pkgbuild/ins/PKGBUILD
+++ b/pkgbuild/ins/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.13.26
+pkgver=0.13.27
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION



## 🤖 New release

* `ins`: 0.13.26 -> 0.13.27

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.13.27](https://github.com/instantOS/instantCLI/compare/v0.13.26...v0.13.27) - 2026-04-27

### Other

- update readme
- better `ins arch` error handling
- add desktop environment question to `ins arch`
- more encapsulation
- better push handling of local only repos
- cleaner preview method
- cleaner exit
- skip repos which ignore file in menu
- earlier ignore checks
- home dir support for ins ignore
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling with enhanced desktop environment detection
  * Fixed handling of local-only repository pushes

* **Improvements**
  * Enhanced menu and ignore functionality with earlier checks
  * Added support for ignore paths in home directory
  * Streamlined preview and exit flows

* **Documentation**
  * Updated documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->