### PR TITLE
chore: release v0.13.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.28](https://github.com/instantOS/instantCLI/compare/v0.13.27...v0.13.28) - 2026-05-04
+
+### Fixed
+
+- fix i3 getting sway only config
+- fix unnecessary reloads
+- fix messed up menus
+- fix back button for warning questions
+- fix resolvething bugs
+- fix resolvething errors
+
+### Other
+
+- centralize some utils
+- finish old module refactor
+- make disk operations more testable
+- more thorough lvm probing
+- better `ins dev chroot` reports
+- deduplicate `ins dev chroot`
+- init ins dev chroot
+- more semantic fzf improvements
+- better compile time safety for fzf builder
+- Merge pull request #136 from instantOS/release-plz-2026-04-27T23-02-41Z
+- remove libgit2 references
+- context aware menu filtering for dotfile dirs
+- adjust `ins menu` for root owned dotfiles
+- init support for root owned dotfiles
+- better enforce deletion invariants
+- add trashbin size doctor check
+- simplify resolvething
+- account for more resolvething edge cases
+- add singleton skip reason
+- add dry-run for resolvething
+- more sensitive resolvething behavior
+- auto resolve stversions duplicates
+- add way to show ignored duplicates
+- rework resolvething
+- do not hardcode tmp dir, fix trash on termux
+- more robust yazi handling
+- add resolvething
+- Merge branch 'dev' of github.com:instantOS/instantCLI into dev
+- update deps
+
 ## [0.13.27](https://github.com/instantOS/instantCLI/compare/v0.13.26...v0.13.27) - 2026-04-27
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.13.27"
+version = "0.13.28"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.13.27"
+version = "0.13.28"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"

--- a/pkgbuild/ins/.SRCINFO
+++ b/pkgbuild/ins/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ins
 	pkgdesc = A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations
-	pkgver = 0.13.27
+	pkgver = 0.13.28
 	pkgrel = 1
 	url = https://instantos.io
 	arch = x86_64
@@ -14,7 +14,7 @@ pkgbase = ins
 	optdepends = restic: for backup functionality
 	optdepends = kitty: default terminal for scratchpad
 	options = !lto
-	source = ins-0.13.27.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.27.tar.gz
+	source = ins-0.13.28.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.28.tar.gz
 	sha256sums = SKIP
 
 pkgname = ins

--- a/pkgbuild/ins/PKGBUILD
+++ b/pkgbuild/ins/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.13.27
+pkgver=0.13.28
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION



## 🤖 New release

* `ins`: 0.13.27 -> 0.13.28

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.13.28](https://github.com/instantOS/instantCLI/compare/v0.13.27...v0.13.28) - 2026-05-04

### Fixed

- fix i3 getting sway only config
- fix unnecessary reloads
- fix messed up menus
- fix back button for warning questions
- fix resolvething bugs
- fix resolvething errors

### Other

- centralize some utils
- finish old module refactor
- make disk operations more testable
- more thorough lvm probing
- better `ins dev chroot` reports
- deduplicate `ins dev chroot`
- init ins dev chroot
- more semantic fzf improvements
- better compile time safety for fzf builder
- Merge pull request #136 from instantOS/release-plz-2026-04-27T23-02-41Z
- remove libgit2 references
- context aware menu filtering for dotfile dirs
- adjust `ins menu` for root owned dotfiles
- init support for root owned dotfiles
- better enforce deletion invariants
- add trashbin size doctor check
- simplify resolvething
- account for more resolvething edge cases
- add singleton skip reason
- add dry-run for resolvething
- more sensitive resolvething behavior
- auto resolve stversions duplicates
- add way to show ignored duplicates
- rework resolvething
- do not hardcode tmp dir, fix trash on termux
- more robust yazi handling
- add resolvething
- Merge branch 'dev' of github.com:instantOS/instantCLI into dev
- update deps
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed i3/sway configuration behavior issues
  * Resolved reload, menu, back-button, and warning-related problems
  * Fixed resolvething functionality issues
  * Addressed multiple warning and error handling scenarios

* **Other**
  * Centralized and refactored utility code
  * Enhanced chroot-related improvements
  * Improved fzf safety and semantic handling
  * Enhanced dotfile and root path handling
  * Removed libgit2 dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->