### PR TITLE
chore: release v0.13.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.29](https://github.com/instantOS/instantCLI/compare/v0.13.28...v0.13.29) - 2026-05-05
+
+### Fixed
+
+- fix CI
+
+### Other
+
+- dedupe xdg dir retrieval
+
 ## [0.13.28](https://github.com/instantOS/instantCLI/compare/v0.13.27...v0.13.28) - 2026-05-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.13.28"
+version = "0.13.29"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.13.28"
+version = "0.13.29"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"

--- a/pkgbuild/ins/.SRCINFO
+++ b/pkgbuild/ins/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ins
 	pkgdesc = A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations
-	pkgver = 0.13.28
+	pkgver = 0.13.29
 	pkgrel = 1
 	url = https://instantos.io
 	arch = x86_64
@@ -14,7 +14,7 @@ pkgbase = ins
 	optdepends = restic: for backup functionality
 	optdepends = kitty: default terminal for scratchpad
 	options = !lto
-	source = ins-0.13.28.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.28.tar.gz
+	source = ins-0.13.29.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.29.tar.gz
 	sha256sums = SKIP
 
 pkgname = ins

--- a/pkgbuild/ins/PKGBUILD
+++ b/pkgbuild/ins/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.13.28
+pkgver=0.13.29
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION



## 🤖 New release

* `ins`: 0.13.28 -> 0.13.29

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.13.29](https://github.com/instantOS/instantCLI/compare/v0.13.28...v0.13.29) - 2026-05-05

### Fixed

- fix CI

### Other

- dedupe xdg dir retrieval
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * v0.13.29 published.

* **Bug Fixes**
  * Resolved continuous integration pipeline issues to improve release reliability.

* **Other**
  * Optimized XDG directory handling by removing redundant retrievals for better performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->