### PR TITLE
chore: release v0.13.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.31](https://github.com/instantOS/instantCLI/compare/v0.13.30...v0.13.31) - 2026-05-08
+
+### Other
+
+- Merge pull request #140 from instantOS/release-plz-2026-05-07T10-07-15Z
+
 ## [0.13.30](https://github.com/instantOS/instantCLI/compare/v0.13.29...v0.13.30) - 2026-05-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.13.30"
+version = "0.13.31"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.13.30"
+version = "0.13.31"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"

--- a/pkgbuild/ins/.SRCINFO
+++ b/pkgbuild/ins/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ins
 	pkgdesc = A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations
-	pkgver = 0.13.30
+	pkgver = 0.13.31
 	pkgrel = 1
 	url = https://instantos.io
 	arch = x86_64
@@ -14,7 +14,7 @@ pkgbase = ins
 	optdepends = restic: for backup functionality
 	optdepends = kitty: default terminal for scratchpad
 	options = !lto
-	source = ins-0.13.30.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.30.tar.gz
+	source = ins-0.13.31.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.31.tar.gz
 	sha256sums = SKIP
 
 pkgname = ins

--- a/pkgbuild/ins/PKGBUILD
+++ b/pkgbuild/ins/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.13.30
+pkgver=0.13.31
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION
## 🤖 New release

* `ins`: 0.13.30 -> 0.13.31

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.13.31](https://github.com/instantOS/instantCLI/compare/v0.13.30...v0.13.31) - 2026-05-08

### Other

- Merge pull request #140 from instantOS/release-plz-2026-05-07T10-07-15Z
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

## Summary by Sourcery

Chores:
- Bump the ins crate version from 0.13.30 to 0.13.31 and record the release in the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.13.31.
  * Added a 0.13.31 release entry to the changelog dated 2026-05-08 documenting the new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->