### PR TITLE
chore: release v0.13.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.36](https://github.com/instantOS/instantCLI/compare/v0.13.35...v0.13.36) - 2026-06-02
+
+### Other
+
+- better external repo handling in CLI
+- handle external repos better in root flow
+- better root add dotfiles flow
+- init wallpaper support for niri
+- tap to click for niri
+- refactor niri a bit
+- unify niri and sway handling more
+- improve false compositor detection
+- Merge pull request #145 from instantOS/release-plz-2026-05-25T17-29-58Z
+- add back button to snapshot selection
+- add kooha assist
+- add fastfetch preview
+- add figlet to caffeine
+- Merge branch 'main' into dev
+- better theme preview
+
 ## [0.13.35](https://github.com/instantOS/instantCLI/compare/v0.13.34...v0.13.35) - 2026-05-25
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.13.35"
+version = "0.13.36"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.13.35"
+version = "0.13.36"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"

--- a/pkgbuild/ins/.SRCINFO
+++ b/pkgbuild/ins/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ins
 	pkgdesc = A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations
-	pkgver = 0.13.35
+	pkgver = 0.13.36
 	pkgrel = 1
 	url = https://instantos.io
 	arch = x86_64
@@ -14,7 +14,7 @@ pkgbase = ins
 	optdepends = restic: for backup functionality
 	optdepends = kitty: default terminal for scratchpad
 	options = !lto
-	source = ins-0.13.35.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.35.tar.gz
+	source = ins-0.13.36.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.36.tar.gz
 	sha256sums = SKIP
 
 pkgname = ins

--- a/pkgbuild/ins/PKGBUILD
+++ b/pkgbuild/ins/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.13.35
+pkgver=0.13.36
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION



## 🤖 New release

* `ins`: 0.13.35 -> 0.13.36

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.13.36](https://github.com/instantOS/instantCLI/compare/v0.13.35...v0.13.36) - 2026-06-02

### Other

- better external repo handling in CLI
- handle external repos better in root flow
- better root add dotfiles flow
- init wallpaper support for niri
- tap to click for niri
- refactor niri a bit
- unify niri and sway handling more
- improve false compositor detection
- Merge pull request #145 from instantOS/release-plz-2026-05-25T17-29-58Z
- add back button to snapshot selection
- add kooha assist
- add fastfetch preview
- add figlet to caffeine
- Merge branch 'main' into dev
- better theme preview
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).