### PR TITLE
chore: release v0.13.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.37](https://github.com/instantOS/instantCLI/compare/v0.13.36...v0.13.37) - 2026-06-06
+
+### Fixed
+
+- fix ins arch deps
+
+### Other
+
+- Merge branch 'dev'
+- add ntfsprogs
+
 ## [0.13.36](https://github.com/instantOS/instantCLI/compare/v0.13.35...v0.13.36) - 2026-06-05
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.13.36"
+version = "0.13.37"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.13.36"
+version = "0.13.37"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"

--- a/pkgbuild/ins/.SRCINFO
+++ b/pkgbuild/ins/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ins
 	pkgdesc = A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations
-	pkgver = 0.13.36
+	pkgver = 0.13.37
 	pkgrel = 1
 	url = https://instantos.io
 	arch = x86_64
@@ -13,8 +13,10 @@ pkgbase = ins
 	depends = sqlite
 	optdepends = restic: for backup functionality
 	optdepends = kitty: default terminal for scratchpad
+	optdepends = ntfsprogs: for NTFS partition resize detection (dual-boot)
+	optdepends = ntfs-3g: for mounting Windows NTFS partitions (dual-boot)
 	options = !lto
-	source = ins-0.13.36.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.36.tar.gz
+	source = ins-0.13.37.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.13.37.tar.gz
 	sha256sums = SKIP
 
 pkgname = ins

--- a/pkgbuild/ins/PKGBUILD
+++ b/pkgbuild/ins/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.13.36
+pkgver=0.13.37
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION
## 🤖 New release

* `ins`: 0.13.36 -> 0.13.37

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.13.37](https://github.com/instantOS/instantCLI/compare/v0.13.36...v0.13.37) - 2026-06-06

### Fixed

- fix ins arch deps

### Other

- Merge branch 'dev'
- add ntfsprogs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

## Summary by Sourcery

Release ins crate version 0.13.37 with updated changelog for the new release.

Bug Fixes:
- Document fixing of ins Arch Linux dependencies in the changelog.

Enhancements:
- Record addition of ntfsprogs and recent dev branch merge in the changelog.

Build:
- Bump ins crate version from 0.13.36 to 0.13.37 in Cargo metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed architecture dependency issues

* **New Features**
  * Added optional NTFS utilities for resize detection and mounting

* **Chores**
  * Bumped release version to 0.13.37

* **Documentation**
  * Added a 0.13.37 release entry to the changelog
<!-- end of auto-generated comment: release notes by coderabbit.ai -->