### PR TITLE
chore: release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1](https://github.com/instantOS/instantCLI/compare/v0.14.0...v0.14.1) - 2026-06-18
+
+### Fixed
+
+- fix apt removal thingy
+
+### Other
+
+- inline trivial forwarding functions
+- add apt support for removal cascade
+- make wine save scanning more robust
+- add orbit compat
+
 ## [0.14.0](https://github.com/instantOS/instantCLI/compare/v0.13.37...v0.14.0) - 2026-06-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"


### PR DESCRIPTION
## 🤖 New release

* `ins`: 0.14.0 -> 0.14.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.14.1](https://github.com/instantOS/instantCLI/compare/v0.14.0...v0.14.1) - 2026-06-18

### Fixed

- fix apt removal thingy

### Other

- inline trivial forwarding functions
- add apt support for removal cascade
- make wine save scanning more robust
- add orbit compat
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

## Summary by Sourcery

Prepare the 0.14.1 release of the ins crate.

Build:
- Bump ins crate version from 0.14.0 to 0.14.1 in Cargo metadata.

Documentation:
- Add changelog entry for v0.14.1 with notes on fixes and other minor improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed apt package removal behavior issues
  * Added support for cascading apt removal operations
  * Improved robustness of wine save file scanning
  * Enhanced compatibility with orbit functionality

* **Performance Improvements**
  * Code optimizations and efficiency enhancements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->