### PR TITLE
chore: release v0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.3](https://github.com/instantOS/instantCLI/compare/v0.14.2...v0.14.3) - 2026-06-29
+
+### Fixed
+
+- fix home dir on bazzite
+
+### Other
+
+- fmt
+- add ssh menu
+- Merge branch 'dev' of github.com:instantOS/instantCLI into dev
+- doc choose
+
 ## [0.14.2](https://github.com/instantOS/instantCLI/compare/v0.14.1...v0.14.2) - 2026-06-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"


### PR DESCRIPTION
## 🤖 New release

* `ins`: 0.14.2 -> 0.14.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.14.3](https://github.com/instantOS/instantCLI/compare/v0.14.2...v0.14.3) - 2026-06-29

### Fixed

- fix home dir on bazzite

### Other

- fmt
- add ssh menu
- Merge branch 'dev' of github.com:instantOS/instantCLI into dev
- doc choose
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

## Summary by Sourcery

Prepare the v0.14.3 release of the ins CLI, updating metadata and changelog.

Build:
- Bump crate version from 0.14.2 to 0.14.3 in Cargo metadata.

Documentation:
- Add changelog entry for v0.14.3 detailing fixes and other changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app version to **0.14.3**.
  * Added a new release entry to the changelog with recent fixes and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->