### PR TITLE
chore: release v0.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.6](https://github.com/instantOS/instantCLI/compare/v0.14.5...v0.14.6) - 2026-07-20
+
+### Fixed
+
+- fix mktemp installation
+- fix archinstall.sh
+- fix escalation and installer opening
+
+### Other
+
+- add dev install package arg
+- Make sure ins arch install is run in a terminal
+
 ## [0.14.5](https://github.com/instantOS/instantCLI/compare/v0.14.4...v0.14.5) - 2026-07-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.14.5"
+version = "0.14.6"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"

--- a/pkgbuild/ins/.SRCINFO
+++ b/pkgbuild/ins/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ins
 	pkgdesc = A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations
-	pkgver = 0.14.5
+	pkgver = 0.14.6
 	pkgrel = 1
 	url = https://instantos.io
 	arch = x86_64
@@ -18,7 +18,7 @@ pkgbase = ins
 	optdepends = ntfsprogs: for NTFS partition resize detection (dual-boot)
 	optdepends = ntfs-3g: for mounting Windows NTFS partitions (dual-boot)
 	options = !lto
-	source = ins-0.14.5.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.14.5.tar.gz
+	source = ins-0.14.6.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.14.6.tar.gz
 	sha256sums = SKIP
 
 pkgname = ins

--- a/pkgbuild/ins/PKGBUILD
+++ b/pkgbuild/ins/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.14.5
+pkgver=0.14.6
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION



## 🤖 New release

* `ins`: 0.14.5 -> 0.14.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.14.6](https://github.com/instantOS/instantCLI/compare/v0.14.5...v0.14.6) - 2026-07-20

### Fixed

- fix mktemp installation
- fix archinstall.sh
- fix escalation and installer opening

### Other

- add dev install package arg
- Make sure ins arch install is run in a terminal
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issues affecting temporary-directory installation, `archinstall.sh`, escalation, and installer launching.
  * Ensured `ins arch` opens in a terminal as expected.

* **Improvements**
  * Added support for passing a package argument during development installations.

* **Release**
  * Released version 0.14.6 with updated package metadata and distribution information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->