### PR TITLE
chore: release v0.14.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.8](https://github.com/instantOS/instantCLI/compare/v0.14.7...v0.14.8) - 2026-08-08
+
+### Fixed
+
+- fix normalizer
+- fix menu chord navigation state tracking
+
+### Other
+
+- Migrate workflows to Blacksmith
+- init clearvoice enhancer
+- rename preprocessor
+- add Granite ASR backend via transcribe.cpp
+- dedupe video module copy-paste
+- remove duplication from previewriter
+- dedupe game disco
+- remove old xsetroot instantwm command
+- clippy
+- better instantwm ins assist
+- bump stuff
+- dedupe wayland copying
+- fmt
+- Merge pull request #157 from instantOS/release-plz-2026-07-22T21-01-58Z
+- bette git repo preview
+- clippy
+- better chord menu columns
+- nicer looking package installation headr
+- init better looking key chord menu
+- rework fzf api
+
 ## [0.14.7](https://github.com/instantOS/instantCLI/compare/v0.14.6...v0.14.7) - 2026-07-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "ins"
-version = "0.14.7"
+version = "0.14.8"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ins"
-version = "0.14.7"
+version = "0.14.8"
 edition = "2024"
 description = "Instant CLI - command-line utilities"
 license = "GPL-2.0-only"

--- a/pkgbuild/ins/.SRCINFO
+++ b/pkgbuild/ins/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ins
 	pkgdesc = A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations
-	pkgver = 0.14.7
+	pkgver = 0.14.8
 	pkgrel = 1
 	url = https://instantos.io
 	arch = x86_64
@@ -30,7 +30,7 @@ pkgbase = ins
 	replaces = instantupdate
 	replaces = instantwelcome
 	options = !lto
-	source = ins-0.14.7.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.14.7.tar.gz
+	source = ins-0.14.8.tar.gz::https://github.com/instantOS/instantCLI/archive/refs/tags/v0.14.8.tar.gz
 	sha256sums = SKIP
 
 pkgname = ins

--- a/pkgbuild/ins/PKGBUILD
+++ b/pkgbuild/ins/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=ins
-pkgver=0.14.7
+pkgver=0.14.8
 pkgrel=1
 pkgdesc="A powerful command-line tool for managing dotfiles, system diagnostics, and instantOS configurations"
 arch=('x86_64')


### PR DESCRIPTION



## 🤖 New release

* `ins`: 0.14.7 -> 0.14.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.14.8](https://github.com/instantOS/instantCLI/compare/v0.14.7...v0.14.8) - 2026-08-08

### Fixed

- fix normalizer
- fix menu chord navigation state tracking

### Other

- Migrate workflows to Blacksmith
- init clearvoice enhancer
- rename preprocessor
- add Granite ASR backend via transcribe.cpp
- dedupe video module copy-paste
- remove duplication from previewriter
- dedupe game disco
- remove old xsetroot instantwm command
- clippy
- better instantwm ins assist
- bump stuff
- dedupe wayland copying
- fmt
- Merge pull request #157 from instantOS/release-plz-2026-07-22T21-01-58Z
- bette git repo preview
- clippy
- better chord menu columns
- nicer looking package installation headr
- init better looking key chord menu
- rework fzf api
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).